### PR TITLE
Fix removal of the event listener on agents without EventListenerOptions support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ const options = {
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
 w.addEventListener && w.addEventListener('p', noop, options);
-w.removeEventListener && w.removeEventListener('p', noop, false);
+w.removeEventListener && w.removeEventListener('p', noop, !passiveOptionAccessed);
 
 export const supportsPassiveEvents: boolean = passiveOptionAccessed;
 


### PR DESCRIPTION
The capture flag needs to match the `addEventListener` on `removeEventListener` or else the event listener is not removed.